### PR TITLE
Fix image builder version output

### DIFF
--- a/.github/assets/shell/createUpdateImageBuilder.sh
+++ b/.github/assets/shell/createUpdateImageBuilder.sh
@@ -121,6 +121,8 @@ else
 
   if diff -q "$PARAMETERS_FILE" /tmp/latest_parameters.json > /dev/null; then
     echo "No changes detected in parameters. Skipping stack update."
+    # Write out the current version for downstream steps before exiting
+    echo "version=$CURRENT_VERSION" > IMAGE-BUILDER.txt
     echo "needImageRebuild=false" >> "$GITHUB_ENV"
     exit 0
   else


### PR DESCRIPTION
## Summary
- ensure createUpdateImageBuilder.sh always writes IMAGE-BUILDER.txt even when exiting early

## Testing
- `npm test` *(fails: ENOENT)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68681b2bc24083259f4e278b56bf00d7