### PR TITLE
feat: add ALB listener template with per-rule certificates

### DIFF
--- a/CloudFormation/web.yaml
+++ b/CloudFormation/web.yaml
@@ -112,9 +112,9 @@ Parameters:
     Description: Add a UDP listener to the NLB
     Default: "false"
 
-  CertificateArns:
-    Type: CommaDelimitedList # List<AWS::CertificateManager::Certificate::Arn>
-    Description: List of ACM certificates to be used by the load balancer listener
+  CertificateArn:
+    Type: String
+    Description: ACM certificate to attach to the load balancer listener
     Default: ""
 
   UseGitHubRunNumberForASG:
@@ -128,8 +128,8 @@ Parameters:
 Conditions:
   linkAlb: !Equals [ !Ref AddAlbListener, 'true' ]
   linkNlb: !Equals [ !Ref AddNlbListener, 'true' ]
-  HasCertificates: !Not [ !Equals [ !Join [ "", !Ref CertificateArns ], "" ] ]
-  linkAlbWithCerts: !And [ !Condition linkAlb, !Condition HasCertificates ]
+  HasCertificate: !Not [ !Equals [ !Ref CertificateArn, "" ] ]
+  linkAlbWithCert: !And [ !Condition linkAlb, !Condition HasCertificate ]
   HasLoadBalancerHosts: !Not [ !Equals [ !Join [ "",  !Ref LoadBalancerHosts], "" ] ]
   IncludeGitHubRunNumberForASG: !Equals [!Ref UseGitHubRunNumberForASG, 'true']
 
@@ -176,8 +176,16 @@ Resources:
       ListenerArn: !ImportValue PublicAlbHttpListenerArn
       Priority: !Ref LoadBalancerRulePriority
 
+  AlbHttpsListenerCertificate:
+    Condition: linkAlbWithCert
+    Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      ListenerArn: !ImportValue PublicAlbHttpsListenerArn
+
   AlbHttpsListenerRule:
-    Condition: linkAlbWithCerts
+    Condition: linkAlb
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
       Actions:


### PR DESCRIPTION
## Summary
- add dedicated ALB CloudFormation template with default cert and host rule
- allow application stacks to attach their own certificates and listener rules
- document branch-based domain and database parameters in README
- generate ALB template at runtime and drop committed `CloudFormation/alb.yaml`

## Testing
- `php -l .github/assets/php/createAlbYaml.php`
- `php .github/assets/php/createAlbYaml.php > /tmp/alb.yaml && cfn-lint /tmp/alb.yaml CloudFormation/web.yaml` *(warn: Parameter RunNumber not used)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba1c54a88325a065fc5f0f0c4408