### PR TITLE
feat: expose database identifier prefix

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: string
         default: 'RdsDatabase'
+      databaseInstanceIdentifierPrefix:
+        description: 'Instance identifier prefix for RDS resources'
+        required: false
+        type: string
+        default: 'mydb'
       databaseMultiAZ:
         description: 'Multi-AZ deployment (true or false)'
         required: false
@@ -858,6 +863,7 @@ jobs:
             ParameterKey=DatabaseMasterUsername,ParameterValue="${{ inputs.databaseMasterUsername }}" \
             ParameterKey=DatabaseMasterPassword,ParameterValue="${{ inputs.databaseMasterPassword }}" \
             ParameterKey=DatabaseName,ParameterValue="${{ inputs.databaseName }}" \
+            ParameterKey=InstanceIdentifierPrefix,ParameterValue="${{ inputs.databaseInstanceIdentifierPrefix }}" \
             ParameterKey=MultiAZ,ParameterValue="${{ inputs.databaseMultiAZ }}" \
             ParameterKey=PubliclyAccessible,ParameterValue="${{ inputs.databasePubliclyAccessible }}" \
             ParameterKey=AllocatedStorage,ParameterValue="${{ inputs.databaseAllocatedStorage }}" \


### PR DESCRIPTION
## Summary
- allow configuring database InstanceIdentifierPrefix via workflow inputs
- pass InstanceIdentifierPrefix to RDS CloudFormation stack

## Testing
- `cfn-lint CloudFormation/database.yaml`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a95bd33a548325a2594a7413759174