### PR TITLE
Use load balancer data for Route53 aliases

### DIFF
--- a/.github/assets/shell/updateRoute53Alias.sh
+++ b/.github/assets/shell/updateRoute53Alias.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -eEBx
+
+# Ensure that three arguments (domain, load balancer DNS, canonical hosted zone ID) are provided
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <domain> <load balancer dns> <canonical hosted zone id>"
+  exit 1
+fi
+
+DOMAIN=$1
+LB_DNS=$2
+LB_ZONE=$3
+
+# Traverse domain to find hosted zone
+FULL_DOMAIN="$DOMAIN"
+while [[ "$FULL_DOMAIN" == *.* ]]; do
+  HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$FULL_DOMAIN" \
+    --query "HostedZones[?Name == '$FULL_DOMAIN.'].Id" --output text)
+  if [[ -n "$HOSTED_ZONE_ID" && "$HOSTED_ZONE_ID" != "None" ]]; then
+    break
+  fi
+  FULL_DOMAIN="${FULL_DOMAIN#*.}"
+done
+
+if [[ -z "$HOSTED_ZONE_ID" || "$HOSTED_ZONE_ID" == "None" ]]; then
+  echo "No hosted zone found for $DOMAIN"
+  exit 1
+fi
+
+# UPSERT the A alias record
+aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "{
+  \"Changes\": [{
+    \"Action\": \"UPSERT\",
+    \"ResourceRecordSet\": {
+      \"Name\": \"$DOMAIN\",
+      \"Type\": \"A\",
+      \"AliasTarget\": {
+        \"HostedZoneId\": \"$LB_ZONE\",
+        \"DNSName\": \"$LB_DNS\",
+        \"EvaluateTargetHealth\": false
+      }
+    }
+  }]
+}"
+
+echo "✅ Route 53 alias record created or updated for $DOMAIN → $LB_DNS in zone $FULL_DOMAIN ($HOSTED_ZONE_ID)"

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -783,6 +783,38 @@ jobs:
           ParameterKey=VpcId,ParameterValue="${{ env.vpc }}" \
           ParameterKey=PublicSubnets,ParameterValue="${{ env.publicAZASubnet }}"
 
+      - name: Capture load balancer DNS
+        if: ${{ inputs.domains != '' }}
+        run: |
+          set -eEBx
+          if aws cloudformation describe-stacks --stack-name nlb >/dev/null 2>&1; then
+            LB_DNS=$(aws cloudformation describe-stacks --stack-name nlb --query "Stacks[0].Outputs[?OutputKey=='PublicNlbDnsName'].OutputValue" --output text)
+            LB_ZONE=$(aws cloudformation describe-stacks --stack-name nlb --query "Stacks[0].Outputs[?OutputKey=='PublicNlbCanonicalHostedZoneId'].OutputValue" --output text)
+          else
+            LB_DNS=$(aws cloudformation describe-stacks --stack-name alb --query "Stacks[0].Outputs[?OutputKey=='PublicAlbDnsName'].OutputValue" --output text)
+            LB_ZONE=$(aws cloudformation describe-stacks --stack-name alb --query "Stacks[0].Outputs[?OutputKey=='PublicAlbCanonicalHostedZoneId'].OutputValue" --output text)
+          fi
+          echo "LB_DNS=$LB_DNS" >> $GITHUB_ENV
+          echo "LB_ZONE=$LB_ZONE" >> $GITHUB_ENV
+
+      - name: Authenticate to Shared Networking Account for DNS
+        if: ${{ inputs.domains != '' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "${{ inputs.networkAccountOidcRole }}"
+          role-session-name: github-actions-oidc-session
+          aws-region: "${{ matrix.aws-region }}"
+          mask-aws-account-id: 'no'
+
+      - name: Upsert Route53 alias
+        if: ${{ inputs.domains != '' }}
+        run: |
+          set -eEBx
+          IFS=',' read -ra DOMAINS <<< "${{ inputs.domains }}"
+          for domain in "${DOMAINS[@]}"; do
+            ./.github/assets/shell/updateRoute53Alias.sh "$domain" "$LB_DNS" "$LB_ZONE"
+          done
+
       # It is possible for no variables to be in this file, so we touch it first
       - name: Create ENV variables
         run: |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ https://docs.aws.amazon.com/controltower/latest/userguide/creating-resources-wit
     - MAGE-BUILDER: Builds and manages Amazon Machine Images (AMI) using AWS Image Builder.
     - DEPLOY: Deploys the application stack and manages auto-scaling groups.
 
+### DNS Alias Selection
+
+After the load balancer stacks are created, the workflow upserts a Route 53 A-record alias for each domain in `inputs.domains`. If a Network Load Balancer (NLB) stack exists, its DNS name and canonical hosted zone ID are used for the alias. Otherwise, the Application Load Balancer (ALB) values are used.
+
 ### GitHub Actions OIDC (actions aws setup)
 
 Create the OIDC role for the GitHub Actions workflow to assume.


### PR DESCRIPTION
## Summary
- support A record aliases via new updateRoute53Alias.sh
- update workflow to alias domains to NLB or ALB
- document DNS preference for NLB over ALB

## Testing
- `shellcheck .github/assets/shell/updateRoute53Alias.sh`
- `yamllint .github/workflows/aws.yml` *(fails: many line-length and style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc39bfcc8325bd4c0b3c44d86b5d