### PR TITLE
feat: allow variable overrides via artifact

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -365,8 +365,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Fetch all tags
         run: git fetch --all --tags
@@ -470,8 +474,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Configure AWS credentials for Shared Networking Account (${{ needs.CONSTANTS.outputs.networkingAccountId }}) (${{ (env.networkAccountOidcRole || inputs.networkAccountOidcRole) }})
         uses: aws-actions/configure-aws-credentials@v4
@@ -547,8 +555,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -644,8 +656,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -783,8 +799,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -910,8 +930,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Configure AWS credentials for (${{ (env.accountName || inputs.accountName) }}) account (${{ (env.instanceDeploymentAccountOidcRole || inputs.instanceDeploymentAccountOidcRole) }})
         uses: aws-actions/configure-aws-credentials@v4
@@ -1029,8 +1053,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -1120,8 +1148,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -1282,8 +1314,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Configure AWS credentials for (${{ (env.accountName || inputs.accountName) }}) account (${{ (env.instanceDeploymentAccountOidcRole || inputs.instanceDeploymentAccountOidcRole) }})
         uses: aws-actions/configure-aws-credentials@v4
@@ -1494,8 +1530,12 @@ jobs:
 
       - name: Load variable overrides
         run: |
-          VARS_JSON=$(cat ./vars/vars.json)
-          echo "$VARS_JSON" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_ENV
+          shopt -s nullglob
+          for f in ./vars/*.sh; do
+            echo "Importing $f"
+            cat "$f"
+            source "$f"
+          done
 
       - name: Configure AWS credentials for (${{ (env.accountName || inputs.accountName) }}) account (${{ (env.instanceDeploymentAccountOidcRole || inputs.instanceDeploymentAccountOidcRole) }})
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary
- allow overriding workflow inputs via vars artifact
- download vars artifact and export variables to environment
- reference env vars before falling back to inputs

## Testing
- `python - <<'PY'
import yaml
yaml.safe_load(open('.github/workflows/aws.yml'))
print('YAML OK')
PY`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/aws-deployment/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68aa002068408325a748585c814d22b9