### PR TITLE
feat: make varsArtifactName optional

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -4,8 +4,9 @@ on:
   workflow_call:
     inputs:
       varsArtifactName:
-        required: true
+        required: false
         type: string
+        default: ''
       accountName:
         required: true
         type: string
@@ -332,9 +333,10 @@ jobs:
       imageBuilderScriptBuild: ${{ steps.out.outputs.imageBuilderScriptBuild }}
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.varsArtifactName }}
+          name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
           path: ./vars
       - name: Normalize flags
         id: out
@@ -388,6 +390,7 @@ jobs:
         run: sudo apt-get install jq
 
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -497,6 +500,7 @@ jobs:
     needs: CONSTANTS
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -578,6 +582,7 @@ jobs:
     needs: [ CONSTANTS, SHARED-NETWORKING ]
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -679,6 +684,7 @@ jobs:
     needs: [ CONSTANTS ]  # Ensure it runs after constant setup
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -822,6 +828,7 @@ jobs:
     needs: [ CONSTANTS, REGIONAL-NETWORKING, ACM-AND-ROUTE-53 ]
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -953,6 +960,7 @@ jobs:
     needs: [ FLAGS, CONSTANTS, REGIONAL-NETWORKING ]
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -1076,6 +1084,7 @@ jobs:
       ecr_uri: ${{ steps.ecr-login.outputs.ecr_uri }}
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -1171,6 +1180,7 @@ jobs:
       ecrRepoUri: ${{ steps.ecr.outputs.ecrRepoUri }}
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -1337,6 +1347,7 @@ jobs:
     needs: [ FLAGS, CONSTANTS, REGIONAL-NETWORKING ]
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}
@@ -1553,6 +1564,7 @@ jobs:
     needs: [ CONSTANTS, REGIONAL-NETWORKING, DATABASE, IMAGE-BUILDER, LOAD-BALANCERS, ACM-AND-ROUTE-53 ]
     steps:
       - name: Download variable overrides
+        if: ${{ env.varsArtifactName != '' || inputs.varsArtifactName != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ (env.varsArtifactName || inputs.varsArtifactName) }}


### PR DESCRIPTION
## Summary
- make `varsArtifactName` workflow input optional
- conditionally download variable override artifacts only when provided

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `yamllint .github/workflows/aws.yml` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa10dabf7c832595c2cfb51b4b9113